### PR TITLE
Remove checkIfBackupDirExists error

### DIFF
--- a/src/python3/W40k.py
+++ b/src/python3/W40k.py
@@ -410,9 +410,8 @@ def restoreOriginalFile(src,dst,filename):#Restores original files
 	print("Restoration of unmodified {0} was successfully completed!".format(filename))
 
 def firstTimeRunningSteps():
-	checkIfBackupDirExists()
 	Backup_and_rename_original_file("Local.ini","W40KFilesBackup")
-	Backup_and_rename_original_file("test.txt","W40KFilesBackup")
+	# Backup_and_rename_original_file("test.txt","W40KFilesBackup")
 	Backup_and_rename_original_file("W40k.exe","W40KFilesBackup")
 	Backup_and_rename_original_file("Platform.dll","W40KFilesBackup")
 	Backup_and_rename_original_file("spDx9.dll","W40KFilesBackup")


### PR DESCRIPTION
Thank you for the script.
But I got an error when first starting your script.
![image](https://github.com/user-attachments/assets/77a5f0d5-39f9-478a-9e35-28f5113a684c)

I found that you are calling `checkIfBackupDirExists` twice.
The first call will check for folder exist and create it. Then the second call will check again but this time `isDir` variable isn't updated
So `mkDir` api is called again and throw the error `FileExistsError: [WinError 183] Cannot create a file when that file already exists`

------
This pr remove the redundant `checkIfBackupDirExists` and also remove the `test.txt` file backup (Steam version don't have this file anymore). 

Everything else still working perfectly.
![image](https://github.com/user-attachments/assets/c49cb224-06b7-4cf7-9986-c6c987c9107d)
